### PR TITLE
fix shell shebang's scopes

### DIFF
--- a/themes/Voodoo-color-theme.json
+++ b/themes/Voodoo-color-theme.json
@@ -816,14 +816,14 @@
 		},
 		{
 			"name": "[Shell] Shebang",
-			"scope": "source.shell comment.line.shebang",
+			"scope": "source.shell comment.line.number-sign.shebang.shell",
 			"settings": {
 				"foreground": "#F1D302"
 			}
 		},
 		{
 			"name": "[Shell] Shebang Hash",
-			"scope": "source.shell punctuation.definition.comment.line.shebang",
+			"scope": "source.shell punctuation.definition.comment.shebang.shell",
 			"settings": {
 				"foreground": "#EF476F"
 			}


### PR DESCRIPTION
Looks like the source.shell shebang's scopes changed which styles it like a comment instead of what seemed to be expected based on the theme's json and tokens' names.

Not sure how versioning works with vscode extensions nor what exact styling was intended for said shebang, but I changed the scopes to make it appear red and yellow.

Before
![pre_fix](https://user-images.githubusercontent.com/49127080/82836785-426d5a80-9e95-11ea-885d-96878baff93d.png)

After
![post_fix](https://user-images.githubusercontent.com/49127080/82836798-47caa500-9e95-11ea-9fb0-6ad1b7c8fa8e.png)
