### PR TITLE
Add a few missing workbench colours

### DIFF
--- a/themes/theme-src.json
+++ b/themes/theme-src.json
@@ -113,6 +113,8 @@
         "tab.border": "$dark_blue_background",
         "tab.inactiveBackground": "$dark_blue_background",
         "tab.inactiveForeground": "$blue_secondary",
+        "badge.background": "$blue_secondary_hover",
+        "badge.foreground": "$white",
 
         // Editor Colors
         "editor.background": "$blue_tertiary",
@@ -175,6 +177,11 @@
         "peekViewEditor.matchHighlightBackground": "$blue_highlight_background",
         "peekViewResult.matchHighlightBackground": "$blue_highlight_background",
         "peekViewTitle.background": "$dark_blue_background",
+        "peekViewResult.background": "$darker_blue_background",
+        "peekViewResult.selectionBackground": "$lime_accent",
+        "peekViewResult.selectionForeground": "$dark_blue_background",
+        "peekViewTitleLabel.foreground": "$lime_accent",
+        "peekViewTitleDescription.foreground": "$blue_secondary_light",
 
         // Merge Conflicts
         "merge.currentHeaderBackground": "$green_highlight_tertiary",
@@ -189,10 +196,14 @@
 
         // Status Bar Colors
         "statusBar.background": "$dark_blue_background",
+        "statusBar.noFolderBackground": "$dark_blue_background",
         "statusBar.debuggingBackground": "$red_accent",
 
         // Title Bar Colors
         "titleBar.activeBackground": "$dark_blue_background",
+        "titleBar.activeForeground": "$white",
+        "titleBar.inactiveBackground": "$blue_secondary_hover",
+        "titleBar.inactiveForeground": "$white",
 
         // Extensions
         "extensionButton.prominentForeground": "$white",


### PR DESCRIPTION
Hey @torodovitch, I'm not able to build the theme file, am I doing something wrong?

I'm trying to run this task,

![image](https://user-images.githubusercontent.com/15017759/93552902-1d0cdb00-f9b5-11ea-9c97-7f180a53dfc1.png)

And I'm getting this error

![image](https://user-images.githubusercontent.com/15017759/93552932-2ac26080-f9b5-11ea-978e-303a30d0cc8d.png)

Do I need to run the builder extension first? I feel like I've most likely missed something.

![image](https://user-images.githubusercontent.com/15017759/93553085-7c6aeb00-f9b5-11ea-859d-6ea5efeb5fac.png)

![image](https://user-images.githubusercontent.com/15017759/93553066-74ab4680-f9b5-11ea-80de-d18a1f61ca12.png)

If I'm not doing anything wrong, would you mind building the new theme from my changes here?